### PR TITLE
Fixes issues with newer versions of python3 installed.

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 import json
 import logging
 import os


### PR DESCRIPTION
```
May 26 19:48:19 sb cleaner.py[2384]: /usr/bin/env: ‘python3.5’: No such file or directory
May 26 19:48:19 sb systemd[1]: unionfs_cleaner.service: Main process exited, code=exited, status=1
```
```
Command 'python3.5' not found, did you mean:

command 'python3.7' from deb python3.7-minimal
command 'python3.6' from deb python3.6-minimal

Try: sudo apt install <deb name>
```